### PR TITLE
[8.x] Implement transactional events via marker interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "egulias/email-validator": "^2.1.10",
         "league/commonmark": "^1.3",
         "league/flysystem": "^1.0.8",
+        "loophp/phptree": "^2.6",
         "monolog/monolog": "^2.0",
         "nesbot/carbon": "^2.17",
         "opis/closure": "^3.5",

--- a/src/Illuminate/Contracts/Events/TransactionalEvent.php
+++ b/src/Illuminate/Contracts/Events/TransactionalEvent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Contracts\Events;
+
+/**
+ * Any Event implementing this (marker) interface will respect
+ * the currently ongoing database transactions and will:
+ *
+ * - purge the events in case of a rollback
+ * - dispatch them once the transaction is commited
+ */
+interface TransactionalEvent
+{
+}

--- a/src/Illuminate/Events/HandlesTransactions.php
+++ b/src/Illuminate/Events/HandlesTransactions.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Illuminate\Events;
+
+use Illuminate\Collections\Collection;
+use Illuminate\Contracts\Events\TransactionalEvent;
+use Illuminate\Database\Events\TransactionBeginning;
+use Illuminate\Database\Events\TransactionCommitted;
+use Illuminate\Database\Events\TransactionRolledBack;
+use loophp\phptree\Node\ValueNode;
+use loophp\phptree\Node\ValueNodeInterface;
+
+trait HandlesTransactions
+{
+    /**
+     * The current prepared transaction.
+     *
+     * @var \loophp\phptree\Node\ValueNodeInterface
+     */
+    protected $currentTransaction;
+
+    /**
+     * All pending events in order.
+     *
+     * @var array
+     */
+    protected $events = [];
+
+    /**
+     * Next position for event storing.
+     *
+     * @var int
+     */
+    protected $nextEventIndex = 0;
+
+    /**
+     * Setup listeners for transaction events.
+     *
+     * @return void
+     */
+    protected function setupDatabaseListeners(): void
+    {
+        $this->listen(TransactionBeginning::class, function () {
+            $this->onTransactionBegin();
+        });
+
+        $this->listen(TransactionCommitted::class, function () {
+            $this->onTransactionCommit();
+        });
+
+        $this->listen(TransactionRolledBack::class, function () {
+            $this->onTransactionRollback();
+        });
+    }
+
+    /**
+     * Prepare a new transaction.
+     *
+     * @return void
+     */
+    protected function onTransactionBegin(): void
+    {
+        $transactionNode = new ValueNode(new Collection());
+
+        $this->currentTransaction = $this->isTransactionRunning()
+            ? $this->currentTransaction->add($transactionNode)
+            : $transactionNode;
+
+        $this->currentTransaction = $transactionNode;
+    }
+
+    /**
+     * Add a pending transactional event to the current transaction.
+     *
+     * @param  string|object $event
+     * @param  mixed $payload
+     * @return void
+     */
+    protected function addPendingEvent($event, $payload): void
+    {
+        $eventData = [
+            'event' => $event,
+            'payload' => is_object($payload) ? clone $payload : $payload,
+        ];
+
+        $this->currentTransaction->getValue()->push($eventData);
+        $this->events[$this->nextEventIndex++] = $eventData;
+    }
+
+    /**
+     * Handle transaction commit.
+     *
+     * @return void
+     */
+    protected function onTransactionCommit(): void
+    {
+        if (! $this->isTransactionRunning()) {
+            return;
+        }
+
+        $committedTransaction = $this->finishTransaction();
+
+        if (! $committedTransaction->isRoot()) {
+            return;
+        }
+
+        $this->dispatchPendingEvents();
+    }
+
+    /**
+     * Clear enqueued events for the rollbacked transaction.
+     *
+     * @return void
+     */
+    protected function onTransactionRollback(): void
+    {
+        if (! $this->isTransactionRunning()) {
+            return;
+        }
+
+        $rolledBackTransaction = $this->finishTransaction();
+
+        if ($rolledBackTransaction->isRoot()) {
+            $this->resetEvents();
+
+            return;
+        }
+
+        $this->nextEventIndex -= $rolledBackTransaction->getValue()->count();
+    }
+
+    /**
+     * Check whether there is at least one transaction running.
+     *
+     * @return bool
+     */
+    protected function isTransactionRunning(): bool
+    {
+        if ($this->currentTransaction) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Flush all pending events.
+     *
+     * @return void
+     */
+    protected function dispatchPendingEvents(): void
+    {
+        $events = $this->events;
+        $eventsCount = $this->nextEventIndex;
+        $this->resetEvents();
+
+        for ($i = 0; $i < $eventsCount; $i++) {
+            $event = $events[$i];
+            $this->dispatchEvent($event['event'], $event['payload']);
+        }
+    }
+
+    /**
+     * Check whether an event is a transactional event or not.
+     *
+     * @param  string|object $event
+     * @return bool
+     */
+    protected function isTransactionalEvent($event): bool
+    {
+        if (! $this->isTransactionRunning()) {
+            return false;
+        }
+
+        return $this->shouldHandleTransaction($event);
+    }
+
+    /**
+     * Finish current transaction.
+     *
+     * @return \loophp\phptree\Node\ValueNodeInterface
+     */
+    protected function finishTransaction(): ValueNodeInterface
+    {
+        $finished = $this->currentTransaction;
+        $this->currentTransaction = $finished->getParent();
+
+        return $finished;
+    }
+
+    /**
+     * Reset events list.
+     *
+     * @return void
+     */
+    protected function resetEvents(): void
+    {
+        $this->events = [];
+        $this->nextEventIndex = 0;
+    }
+
+    /**
+     * Check whether an event should be handled by this layer or not.
+     *
+     * @param  string|object  $event
+     * @return bool
+     */
+    protected function shouldHandleTransaction($event): bool
+    {
+        return $event instanceof TransactionalEvent;
+    }
+}

--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -19,7 +19,8 @@
         "illuminate/container": "^8.0",
         "illuminate/contracts": "^8.0",
         "illuminate/macroable": "^8.0",
-        "illuminate/support": "^8.0"
+        "illuminate/support": "^8.0",
+        "loophp/phptree": "^2.6"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -18,6 +18,7 @@
         "illuminate/collections": "^8.0",
         "illuminate/container": "^8.0",
         "illuminate/contracts": "^8.0",
+        "illuminate/database": "^8.0",
         "illuminate/macroable": "^8.0",
         "illuminate/support": "^8.0",
         "loophp/phptree": "^2.6"

--- a/tests/Events/TransactionalDispatcherTest.php
+++ b/tests/Events/TransactionalDispatcherTest.php
@@ -1,0 +1,337 @@
+<?php
+
+namespace Illuminate\Tests\Events;
+
+use Closure;
+use Exception;
+use Illuminate\Contracts\Events\TransactionalEvent;
+use Illuminate\Database\Capsule\Manager;
+use Illuminate\Database\Connection;
+use Illuminate\Events\Dispatcher;
+use Mockery as m;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+class TransactionalDispatcherTest extends TestCase
+{
+    /** @var \Illuminate\Events\Dispatcher */
+    protected $dispatcher;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        unset($_SERVER['__events.test']);
+
+        $this->dispatcher = new Dispatcher;
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testImmediatelyDispatchesEventOutOfTransactions()
+    {
+        $this->dispatcher->listen('foo', function () {
+            $_SERVER['__events.test'] = 'bar';
+        });
+
+        $this->dispatcher->dispatch('foo');
+
+        $this->assertSame('bar', $_SERVER['__events.test']);
+    }
+
+    public function testImmediatelyDispatchesNonTransactionalEvent()
+    {
+        $this->dispatcher->listen('foo', function () {
+            $_SERVER['__events.test'] = 'bar';
+        });
+
+        [$connection, $pdoMock] = $this->getConnectionAndPdoMock();
+        $pdoMock->shouldReceive('beginTransaction', 'commit')->once();
+
+        $connection->transaction(function () {
+            $this->dispatcher->dispatch('foo');
+            $this->assertSame('bar', $_SERVER['__events.test']);
+        });
+
+        $this->assertSame('bar', $_SERVER['__events.test']);
+    }
+
+    public function testDispatchesEventsOnlyAfterTransactionCommits()
+    {
+        $this->dispatcher->listen(CustomEvent1::class, function () {
+            $_SERVER['__events.test'] = 'bar';
+        });
+
+        [$connection, $pdoMock] = $this->getConnectionAndPdoMock();
+        $pdoMock->shouldReceive('beginTransaction', 'commit')->once();
+
+        $connection->transaction(function () {
+            $this->dispatcher->dispatch(new CustomEvent1());
+            $this->assertArrayNotHasKey('__events.test', $_SERVER);
+        });
+
+        $this->assertSame('bar', $_SERVER['__events.test']);
+    }
+
+    public function testForgetDispatchedEventsAfterTransactionCommits()
+    {
+        $this->dispatcher->listen(CustomEvent1::class, function () {
+            $_SERVER['__events.test'] = 'bar';
+        });
+        $this->dispatcher->listen(CustomEvent2::class, function () {
+            $_SERVER['__events.test'] = 'zen';
+        });
+
+        [$connection, $pdoMock] = $this->getConnectionAndPdoMock();
+        $pdoMock->shouldReceive('beginTransaction', 'commit')->twice();
+
+        $connection->transaction(function () {
+            $this->dispatcher->dispatch(new CustomEvent1());
+            $this->dispatcher->dispatch(new CustomEvent2());
+        });
+
+        $connection->transaction(function () {
+            unset($_SERVER['__events.test']);
+        });
+
+        $this->assertArrayNotHasKey('__events.test', $_SERVER);
+    }
+
+    public function testDoNotForgetDispatchedEventsOnSameTransactionLevelAfterRollback()
+    {
+        $this->dispatcher->listen(CustomEvent1::class, function ($event) {
+            $_SERVER['__events.test'] = $_SERVER['__events.test'] ?? [];
+            $_SERVER['__events.test'][] = $event->payload;
+        });
+
+        [$connection, $pdoMock] = $this->getConnectionAndPdoMock();
+        $pdoMock->shouldReceive('beginTransaction', 'commit')->once();
+        $pdoMock->shouldReceive('exec')->times(3); // savepoints
+
+        $connection->transaction(function () use ($connection) {
+            $this->dispatcher->dispatch(new CustomEvent1('first'));
+
+            $connection->transaction(function () {
+                $this->dispatcher->dispatch(new CustomEvent1('second'));
+            });
+
+            try {
+                $connection->transaction(function () {
+                    $this->dispatcher->dispatch(new CustomEvent1('third'));
+                    throw new Exception;
+                });
+            } catch (Exception $e) {
+                //
+            }
+            $this->dispatcher->dispatch(new CustomEvent1('fourth'));
+        });
+
+        $this->assertCount(3, $_SERVER['__events.test']);
+        $this->assertSame('first', $_SERVER['__events.test'][0]);
+        $this->assertSame('second', $_SERVER['__events.test'][1]);
+        $this->assertSame('fourth', $_SERVER['__events.test'][2]);
+    }
+
+    public function testDoNotDispatchEventsAfterNestedTransactionCommits()
+    {
+        $this->dispatcher->listen(CustomEvent1::class, function () {
+            $_SERVER['__events.test'] = 'bar';
+        });
+
+        [$connection, $pdoMock] = $this->getConnectionAndPdoMock();
+        $pdoMock->shouldReceive('beginTransaction', 'commit', 'exec')->once();
+
+        $connection->transaction(function () use ($connection) {
+            $connection->transaction(function () use ($connection) {
+                $this->dispatcher->dispatch(new CustomEvent1());
+            });
+            $this->assertArrayNotHasKey('__events.test', $_SERVER);
+        });
+
+        $this->assertSame('bar', $_SERVER['__events.test']);
+    }
+
+    public function testDoNotDispatchEventsAfterNestedTransactionRollbacks()
+    {
+        $this->dispatcher->listen(CustomEvent1::class, function () {
+            $_SERVER['__events.test'] = 'bar';
+        });
+
+        [$connection, $pdoMock] = $this->getConnectionAndPdoMock();
+        $pdoMock->shouldReceive('beginTransaction')->once();
+        $pdoMock->shouldReceive('exec')->twice();
+
+        try {
+            $connection->transaction(function () use ($connection) {
+                $connection->transaction(function () {
+                    $this->dispatcher->dispatch(new CustomEvent1());
+                    throw new Exception;
+                });
+            });
+        } catch (Exception $e) {
+            //
+        }
+
+        $this->assertArrayNotHasKey('__events.test', $_SERVER);
+    }
+
+    public function testDoNotDispatchEventsAfterOuterTransactionRollback()
+    {
+        $this->dispatcher->listen(CustomEvent1::class, function () {
+            $_SERVER['__events.test'] = 'bar';
+        });
+
+        [$connection, $pdoMock] = $this->getConnectionAndPdoMock();
+        $pdoMock->shouldReceive('beginTransaction', 'exec')->once();
+
+        try {
+            $connection->transaction(function () use ($connection) {
+                $connection->transaction(function () {
+                    $this->dispatcher->dispatch(new CustomEvent1());
+                });
+                throw new Exception;
+            });
+        } catch (Exception $e) {
+            //
+        }
+
+        $this->assertArrayNotHasKey('__events.test', $_SERVER);
+    }
+
+
+    /**
+     * Regression test: Fix infinite loop caused by TransactionCommitted (#12).
+     */
+    public function testNestedTransactionsOnDispatchDoesNotCauseInfiniteLoop()
+    {
+        [$connection, $pdoMock] = $this->getConnectionAndPdoMock();
+        $pdoMock->shouldReceive('beginTransaction', 'commit')->twice();
+
+        $count = 0;
+        $this->dispatcher->listen(CustomEvent1::class, function () use ($connection, &$count) {
+            $connection->transaction(function () use (&$count) {
+                if ($count > 1) {
+                    $this->fail('Infinite loop while dispatching events.');
+                }
+
+                $count++;
+            });
+        });
+
+        $connection->transaction(function () {
+            $this->dispatcher->dispatch(new CustomEvent1());
+        });
+
+        $this->assertSame(1, $count);
+    }
+
+    public function testWithNonDefaultConnections()
+    {
+        $this->dispatcher->listen(CustomEvent1::class, function ($event) {
+            $_SERVER['__events.test'] = $_SERVER['__events.test'] ?? [];
+            $_SERVER['__events.test'][] = $event->payload;
+        });
+
+        $manager = new Manager;
+
+        $manager->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $manager->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ], 'other');
+
+        $db = $manager->getDatabaseManager();
+        $db->setEventDispatcher($this->dispatcher);
+
+        $connection = $db->connection();
+
+        $connection->transaction(function () use ($db) {
+            $this->dispatcher->dispatch(new CustomEvent1('first'));
+
+            $db->connection('other')->transaction(function () {
+                $this->dispatcher->dispatch(new CustomEvent1('second'));
+            });
+        });
+
+        $this->assertCount(2, $_SERVER['__events.test']);
+        $this->assertSame('first', $_SERVER['__events.test'][0]);
+        $this->assertSame('second', $_SERVER['__events.test'][1]);
+    }
+
+    /**
+     * This reproduces the use of DatabaseTransactions and RefreshDatabase traits.
+     */
+    public function testIgnoreCommitsOrRollbacksWhenTransactionsNotRunning()
+    {
+        [$connection, $pdoMock] = $this->getConnectionAndPdoMock();
+        $pdoMock->shouldReceive('beginTransaction', 'rollback')->once();
+
+        $this->withoutTransactionEvents($connection, function () use ($connection) {
+            $connection->beginTransaction();
+        });
+
+        $this->dispatcher->listen(CustomEvent1::class, function () {
+            throw new Exception();
+        });
+
+        try {
+            $connection->beginTransaction();
+            $this->dispatcher->dispatch(new CustomEvent1());
+            $connection->commit();
+        } catch (Exception $e) {
+            $connection->rollBack();
+        }
+
+        $this->withoutTransactionEvents($connection, function () use ($connection) {
+            $connection->rollBack();
+        });
+
+        $this->assertTrue(true);
+    }
+
+    protected function withoutTransactionEvents(Connection $connection, Closure $callback)
+    {
+        $connection->unsetEventDispatcher();
+
+        try {
+            $callback();
+        } finally {
+            $connection->setEventDispatcher($this->dispatcher);
+        }
+    }
+
+    protected function getConnectionAndPdoMock(): array
+    {
+        $pdoMock = m::mock(PDO::class);
+
+        $connection = new Connection($pdoMock);
+        $connection->setEventDispatcher($this->dispatcher);
+
+        return [$connection, $pdoMock];
+    }
+}
+
+class CustomEvent1 implements TransactionalEvent
+{
+    /** @var string|null */
+    public $payload;
+
+    /**
+     * @param string|null $payload
+     */
+    public function __construct($payload = null) {
+        $this->payload = $payload;
+    }
+}
+
+class CustomEvent2 implements TransactionalEvent
+{
+    //
+}


### PR DESCRIPTION
This is a PoC for https://github.com/fntneves/laravel-transactional-events/issues/32 ; see below for the "official to be" Laravel PR description I intend to use and at the end, some notes regarding this.

----
# What does it solve
A "classical problem" of systems with database transaction and events is that the latter is often handled void of the context of the current transaction.

This means in case of database transaction being rolled back, events are often _already_ fired and thus their outcome might or might not reflect the state of the transaction anymore.

This PR attempts to provide a solution for that.

# The implementation
**Only** events implementing the **new** `TransactionalEvent` interface are subject to this handling, the existing event behaviour is **not changed** (ensuring backwards compatibility).

This is based on https://github.com/fntneves/laravel-transactional-events with permission by the author Francisco Neves (see https://github.com/fntneves/laravel-transactional-events/issues/32).

This is a MVP <sup>(*)</sup> implementation focusing on:
- providing the ability to _internally_ store events
- discard them when a transaction is rolled back
- dispatch them when a transaction is commited
- supports nested transactions => events happening within nested transactions are handled on their own level, not affecting other transaction levels

These are slimmed down capabilities provided by the original approach because of doubts if automatic handling of e.g. Eloquent events for transaction is a good idea to start with or the additional complexity of pattern matching to perform on event names (please see the original readme).

#### Why only Events and not e.g. Jobs?
> I often have to dispatch Jobs in transactions which I want to be "transactional safe"

First, why are "Jobs" also interesting to be handled in a transaction-safe way? Two examples:
- job for user registration email is fired, but for some reason the transaction was rolled back => yet the email was sent, now containing invalid information
  => this PR can help solving this
- jobs might get dispatched to external (or of course also internal) system, requiring access to the same database but are run _outside_ the current transaction context.
  In such cases, it's not uncommon that these jobs see the wrong / outdated information in the database and thus might process stale data.
  There are ways to mitigate this, e.g. not passing model IDs but the whole model (Laravel supports serializing them), but this might not always be possible or desired
  => this PR can help solving this

Implementing this only for the event bus is a "basic building block". _It allows to make transactional jobs_ with a bit of glue code: create a transactional job wrapper, tagged by the interface, and wrap the jobs you want to be transactional:

Add a `\App\Events\TransactionalJob.php`:
```php
<?php declare(strict_types = 1);
namespace App\Events;

use Illuminate\Contracts\Events\TransactionalEvent;
use App\Jobs\Job;

class TransactionalJob implements TransactionalEvent
{
    private Job $job;

    public function __construct(Job $job)
    {
        $this->job = $job;
    }

    public function getJob(): Job
    {
        return $this->job;
    }
}
```

In the `EventServiceProvider.php`:
```php
…
        TransactionalJob::class => [
            DispatchJob::class,
        ],
…
```

Add a `\App\Listeners\DispatchJob.php`:
```php
<?php declare(strict_types = 1);
namespace App\Listeners;

use Illuminate\Contracts\Bus\Dispatcher;
use App\Events\TransactionalJob;

class DispatchJob
{
    private Dispatcher $dispatcher;

    public function __construct(Dispatcher $dispatcher)
    {
        $this->dispatcher = $dispatcher;
    }

    public function handle(TransactionalJob $event): void
    {
        $this->dispatcher->dispatch($event->getJob());
    }
}
```
and then use in your code like:
```php
            $this->events->dispatch(new TransactionalJob(new MyActualJob($payload)));
```

(*) [minimal viable product](https://en.wikipedia.org/wiki/Minimum_viable_product)

### Technical considerations:
- A new dependency to https://github.com/loophp/phptree is added; the existing library uses it for handling the nested levels of transactions correctly
- The package `illuminate/event` has to depend on `illuminate/database` to be able to register the event listeners for the transactions
  This is rather a hefty dependency for this, but I didn't see a way without it.
  Maybe future consideration: separate events to listen from individual packages and provide a way to separately depend only on them, much like `illuminate/contracts` works

### Links
- laravel ideas issues 1441

----
### Some notes
- There might be resistance to two changes necessary here:
  - Another new dependency => https://github.com/loophp/phptree (necessary for the nested transaction handling)
    Just a feeling…
  - Added dependency on https://github.com/illuminate/database (necessary for listening on the transaction events)
    Probably "fine" but some might not be happy about this; it's a hefty dependency but we need it makes the events for the transaction to listen on are in this namespace 😢 
- I ported all the tests (#TIL : laravel/framework is only doing pure unit tests, so existing stuff like orchestra provides were out; it took my longer to adapt the tests then to port the actual code 🤪)
- I decided to use a trait because there are only two places of the existing code (constructor, dispatch method
- I tested this code "for real" in a private project (effectively replacing the `fntneves/laravel-transactional-events` library) and it worked (it also has a test suite with >7k tests with many making use of transactional event testing).

### TODO
- [x] Write more details _within_ the commit messages; right now I kept them terse until the overall implementation is presentable. Especially regarding the original author
- [ ] Do we have enough coverage, should / can we do more?
  I checked the coverage and there are a few lines not covered it seems